### PR TITLE
Added support for Unicode DECIMAL EXPONENT SYMBOL on input.

### DIFF
--- a/dispak/encoding.c
+++ b/dispak/encoding.c
@@ -190,6 +190,11 @@ unicode_to_gost (unsigned short val)
 		case 0x83: return 0122;
 		}
 		break;
+	case 0x23:
+		switch ((unsigned char) val) {
+		case 0xe8: return 0020;
+		}
+		break;
 	case 0x25:
 		switch ((unsigned char) val) {
 		case 0xc7: return 0127;


### PR DESCRIPTION
This patch allows input to contain the Unicode decimal exponent symbol, which is part of the GOST 10859 character set and is used by the ALGOL-BESM6 compiler.