### PR TITLE
Some changes which are related ot OS Dubna bring-up

### DIFF
--- a/besmtool/dump.c
+++ b/besmtool/dump.c
@@ -19,6 +19,23 @@ static const char *opname_long_bemsh [16] = {
 	"пб",	"пв",	"выпр",	"стоп",	"пио",	"пино",	"э36",	"цикл",
 };
 
+const char *opname_short_madlen [64] = {
+    "atx",  "stx",  "mod",  "xts",  "a+x",  "a-x",  "x-a",  "amx",
+    "xta",  "aax",  "aex",  "arx",  "avx",  "aox",  "a/x",  "a*x",
+    "apx",  "aux",  "acx",  "anx",  "e+x",  "e-x",  "asx",  "xtr",
+    "rte",  "yta",  "*32",  "ext",  "e+n",  "e-n",  "asn",  "ntr",
+    "ati",  "sti",  "ita",  "its",  "mtj",  "j+m",  "*46",  "*47",
+    "*50",  "*51",  "*52",  "*53",  "*54",  "*55",  "*56",  "*57",
+    "*60",  "*61",  "*62",  "*63",  "*64",  "*65",  "*66",  "*67",
+    "*70",  "*71",  "*72",  "*73",  "*74",  "*75",  "*76",  "*77",
+};
+
+static const char *opname_long_madlen [16] = {
+    "*20",  "*21",  "utc",  "wtc",  "vtm",  "utm",  "uza",  "u1a",
+    "uj",   "vjm",  "ij",   "stop", "vzm",  "v1m",  "*36",  "vlm",
+};
+
+
 /*
  * Печать машинной инструкции с мнемоникой.
  */
@@ -37,10 +54,17 @@ sprint_command (char *str, unsigned cmd)
 		if (cmd & 01000000)
 			addr |= 070000;
 	}
+#ifdef MADLEN
+	if (opcode & 0200)
+		strcpy (str, opname_long_madlen[(opcode >> 3) & 017]);
+	else
+		strcpy (str, opname_short_madlen[opcode]);
+#else
 	if (opcode & 0200)
 		strcpy (str, opname_long_bemsh [(opcode >> 3) & 017]);
 	else
 		strcpy (str, opname_short_bemsh [opcode]);
+#endif
 	str += strlen (str);
 	if (addr) {
 		if (addr >= 077700)

--- a/besmtool/dump.c
+++ b/besmtool/dump.c
@@ -3,6 +3,7 @@
 #include "disk.h"
 #include "encoding.h"
 
+#if !defined(MADLEN)
 const char *opname_short_bemsh [64] = {
 	"зп",	"зпм",	"рег",	"счм",	"сл",	"вч",	"вчоб",	"вчаб",
 	"сч",	"и",	"нтж",	"слц",	"знак",	"или",	"дел",	"умн",
@@ -19,6 +20,7 @@ static const char *opname_long_bemsh [16] = {
 	"пб",	"пв",	"выпр",	"стоп",	"пио",	"пино",	"э36",	"цикл",
 };
 
+#else
 const char *opname_short_madlen [64] = {
     "atx",  "stx",  "mod",  "xts",  "a+x",  "a-x",  "x-a",  "amx",
     "xta",  "aax",  "aex",  "arx",  "avx",  "aox",  "a/x",  "a*x",
@@ -34,7 +36,7 @@ static const char *opname_long_madlen [16] = {
     "*20",  "*21",  "utc",  "wtc",  "vtm",  "utm",  "uza",  "u1a",
     "uj",   "vjm",  "ij",   "stop", "vzm",  "v1m",  "*36",  "vlm",
 };
-
+#endif
 
 /*
  * Печать машинной инструкции с мнемоникой.

--- a/dispak/extra.c
+++ b/dispak/extra.c
@@ -16,6 +16,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <stdint.h>
+#include <ctype.h>
 #include "defs.h"
 #include "disk.h"
 #include "iobuf.h"

--- a/dispak/extra.c
+++ b/dispak/extra.c
@@ -1208,6 +1208,31 @@ e50_15(void)
 	return E_UNIMP;
 }
 
+
+
+int
+e50_76(void)
+{
+	int addr = acc.r & 077777;
+	static ptr tp;
+
+	tp.p_w = addr;
+	tp.p_b = 0;
+	int c;
+
+	while (tp.p_w != 0) {
+		c = getbyte(&tp);
+		c = toupper(c);
+
+		printf ("%c", (c > 037) ? c : '@');
+
+		if (c == 0 || c == 012)
+			break;
+	}
+	printf ("\n");
+	return (E_SUCCESS);
+}
+
 int
 e50(void)
 {
@@ -1243,6 +1268,11 @@ e50(void)
 	case 074:	/* OS Dubna specific */
 		/* Looks like setting up an address to jump on error. */
 		return E_SUCCESS;
+	
+	case 076:	/* OS Dubna specific */
+		/* Term OUTPUT */
+		return e50_76();
+	
 	case 0100:	/* get account id */
 		acc = user;
 		return E_SUCCESS;


### PR DESCRIPTION
I found 2 years old changes are not populated.

1. Added support of MADLEN mnemonics in the dump command of besmtool. It can be enabled by make options, it done just for a personal convenience, e.g.:
      (export CPPFLAGS=-DMADLEN; make -e )

2. Added  e50_76() support in the dispak simulator.  This is "Term OUPUT" (OS Dubna specific) and it is used during OS bring-up.  

3. Fixed  compilation warnings introduced in #1 and #2 